### PR TITLE
Deterministic Contract Deployments

### DIFF
--- a/script/DeployBatchCaller.s.sol
+++ b/script/DeployBatchCaller.s.sol
@@ -6,21 +6,29 @@ import "forge-std/Vm.sol";
 import "src/BatchCallAndSponsor.sol";
 import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "lib/openzeppelin-contracts/contracts/utils/cryptography/MessageHashUtils.sol";
+import "lib/openzeppelin-contracts/contracts/utils/Create2.sol";
 
 contract DeployBatchCaller is Script {
     BatchCallAndSponsor public batchCaller;
+    // This salt will be used for CREATE2 deployment
+    bytes32 public constant SALT = keccak256("BatchCallAndSponsor-v1");
 
     function run() external {
         uint256 deployerPk = vm.envUint("DEPLOYER_KEY");
-        address deployer = vm.addr(deployerPk);
-        console.log("Deployer:", deployer);
+        // Get the bytecode of the contract
+        bytes memory bytecode = type(BatchCallAndSponsor).creationCode;
 
         // Start broadcasting transactions with Alice's private key.
         vm.startBroadcast(deployerPk);
 
-        // Deploy the delegation contract (Alice will delegate calls to this contract).
-        batchCaller = new BatchCallAndSponsor();
+        // Deploy using CREATE2
+        address payable deployedAddress = payable(Create2.deploy(0, SALT, bytecode));
+
+        // Cast the deployed address to BatchCallAndSponsor
+        batchCaller = BatchCallAndSponsor(deployedAddress);
 
         vm.stopBroadcast();
+        // Log the deployed address
+        console2.log("BatchCallAndSponsor deployed to:", deployedAddress);
     }
 }

--- a/script/DeployMultisend.s.sol
+++ b/script/DeployMultisend.s.sol
@@ -6,17 +6,32 @@ import "forge-std/Vm.sol";
 import "src/EOAMultisend.sol";
 import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "lib/openzeppelin-contracts/contracts/utils/cryptography/MessageHashUtils.sol";
+import "lib/openzeppelin-contracts/contracts/utils/Create2.sol";
 
 contract DeployMultisend is Script {
     EOAMultisend public multisend;
+
+    // This salt will be used for CREATE2 deployment
+    // Using a constant salt ensures the same address across all networks
+    bytes32 public constant SALT = keccak256("EOAMultisend-v1");
 
     function run() external {
         uint256 deployerPk = vm.envUint("DEPLOYER_KEY");
 
         vm.startBroadcast(deployerPk);
 
-        multisend = new EOAMultisend();
+        // Get the bytecode of the contract
+        bytes memory bytecode = type(EOAMultisend).creationCode;
+
+        // Deploy using CREATE2
+        address payable deployedAddress = payable(Create2.deploy(0, SALT, bytecode));
+
+        // Cast the deployed address to EOAMultisend
+        multisend = EOAMultisend(deployedAddress);
 
         vm.stopBroadcast();
+
+        // Log the deployed address
+        console2.log("EOAMultisend deployed to:", deployedAddress);
     }
 }


### PR DESCRIPTION
Changes to the deployment script using create2. These should enable us to deploy the contracts to the same address on all networks.